### PR TITLE
Add golangci-lint config and modernize lint invocation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - prealloc
+    - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+
+issues:
+  max-same-issues: 100
+
+run:
+  timeout: 10m


### PR DESCRIPTION
## Summary

Add a golangci-lint v2 `.golangci.yml` so the `lint` target has an explicit, version-controlled configuration aligned with the rest of the AppsCode repositories.

### `.golangci.yml`
- Enable **`bodyclose`**, **`prealloc`**, **`unparam`** on top of the standard set.
- Exclusions (`generated.*\.go`, `client`, `vendor`) via `linters.exclusions.paths`.
- Formatters: **`gofumpt`** + **`goimports`**.

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
